### PR TITLE
Consider avoiding viewport values that prevent users from resizing documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ O objetivo desta parte da atividade é submeter o site escolhido a um validador 
 
 Foram apontados ao todo 29 problemas no HTML do site. Contudo, diversos dos problemas possuem natureza parecida. Por conta disso, eles foram agrupados em 9 categorias abaixo. Cada uma das categorias de problemas será resolvido em um PR diferente, que será anexado ao seu lado após sua realização.
 
-- [ ] Consider avoiding viewport values that prevent users from resizing documents.
+- [ ] Consider avoiding viewport values that prevent users from resizing documents. (#1)
 
 - [ ] Attribute ____ is not serializable as XML 1.0
 

--- a/Shortstay Curitiba.html
+++ b/Shortstay Curitiba.html
@@ -266,8 +266,6 @@
     }
   </style>
   <meta charset="utf-8">
-  <meta name="viewport"
-    content="viewport-fit=cover,width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=0">
   <meta name="description" content="">
 
 


### PR DESCRIPTION
# Problema
O site contém atributos que, teoricamente, impedem o usuário de alterar o tamanho do seu _viewport_ (janela). A mensagem dada pelo validador é

**Consider avoiding viewport values that prevent users from resizing documents.**

# Solução
Remover a _tag_ apontada como problema pelo validador. Após remover esta _tag_, testes mostraram que o site continua responsivo.