### PR TITLE
Attribute ____ is not serializable as XML 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Foram apontados ao todo 29 problemas no HTML do site. Contudo, diversos dos prob
 
 - [x] Consider avoiding viewport values that prevent users from resizing documents. ([#1](https://github.com/eduardo-otte/acessibilidade-padroes-web/pull/1))
 
-- [ ] Attribute ____ is not serializable as XML 1.0 ([#2](https://github.com/eduardo-otte/acessibilidade-padroes-web/pull/2))
+- [X] Attribute ____ is not serializable as XML 1.0 ([#2](https://github.com/eduardo-otte/acessibilidade-padroes-web/pull/2))
 
 - [ ] Attribute ____ not allowed on element ____ at this point
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Foram apontados ao todo 29 problemas no HTML do site. Contudo, diversos dos prob
 
 - [x] Consider avoiding viewport values that prevent users from resizing documents. ([#1](https://github.com/eduardo-otte/acessibilidade-padroes-web/pull/1))
 
-- [ ] Attribute ____ is not serializable as XML 1.0
+- [ ] Attribute ____ is not serializable as XML 1.0 ([#2](https://github.com/eduardo-otte/acessibilidade-padroes-web/pull/2))
 
 - [ ] Attribute ____ not allowed on element ____ at this point
 


### PR DESCRIPTION
# Problema
Alguns atributos possuem formatos que não são serializáveis para XML versão 1.0. Isso pode impedir que estes atributos sejam corretamente enviados pela rede em _browsers_ que utilizam protocolos mais antigos.

# Solução
Isto é um falso positivo do validador. Inspecionando o código fonte do site através do _browser_, percebe-se que estes atributos não estão em lugar algum do HTML. Na verdade, eles se encontram no código JavaScript (JS) da página. Isso indica que estes atributos provavelmente são criados no próprio _browser_ do usuário, pelo _framework_ JS que o site utiliza. Ou seja, estes atributos não trafegam em rede e, portanto, não precisam ser serializados.