### PR TITLE
An img element must have an alt attribute, except under certain conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Foram apontados ao todo 29 problemas no HTML do site. Contudo, diversos dos prob
 
 - [X] Element _____ not allowed as child of element ____ in this context ([#4](https://github.com/eduardo-otte/acessibilidade-padroes-web/pull/4))
 
-- [ ] An `img` element must have an `alt` attribute, except under certain conditions
+- [X] An `img` element must have an `alt` attribute, except under certain conditions ([#5](https://github.com/eduardo-otte/acessibilidade-padroes-web/pull/5))
 
 - [ ] Self-closing syntax (`/>`) used on a non-void HTML element. Ignoring the slash and treating as a start tag.
 

--- a/Shortstay Curitiba.html
+++ b/Shortstay Curitiba.html
@@ -3595,6 +3595,7 @@
         </header>
         <div class="row">
           <article data-v-599ed6e8="" class="position-relative col-md-4 mt-5 mt-md-0"><img data-v-599ed6e8=""
+              alt="Foto de um homem branco do abdômem para cima. No fundo, há uma paisagem bom bastante grama, agumas pedras e o céu ligeiramente nublado. Ele possui bigode, e está utilizando camisa verde e um chapéu de proteção branco com a sigla CER. Ele sorri bastante."
               src="data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%221%22%20height%3D%221%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20%25%7Bw%7D%20%25%7Bh%7D%22%20preserveAspectRatio%3D%22none%22%3E%3Crect%20width%3D%22100%25%22%20height%3D%22100%25%22%20style%3D%22fill%3Atransparent%3B%22%3E%3C%2Frect%3E%3C%2Fsvg%3E"
               class="testimonial__image" width="1" height="1">
             <blockquote data-v-599ed6e8="" class="bg-white shadowed border-rounded p-4 testimonial__text">
@@ -3603,6 +3604,7 @@
             </blockquote>
           </article>
           <article data-v-599ed6e8="" class="position-relative col-md-4 mt-5 mt-md-0"><img data-v-599ed6e8=""
+              alt="Foto de um homem branco olhando para a câmera e sorrindo. Ele utiliza um terno preto, com camisa lilás e uma gravata vermelha, além de um óculos. Ele é careca e não possui barba."
               src="data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%221%22%20height%3D%221%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20%25%7Bw%7D%20%25%7Bh%7D%22%20preserveAspectRatio%3D%22none%22%3E%3Crect%20width%3D%22100%25%22%20height%3D%22100%25%22%20style%3D%22fill%3Atransparent%3B%22%3E%3C%2Frect%3E%3C%2Fsvg%3E"
               class="testimonial__image" width="1" height="1">
             <blockquote data-v-599ed6e8="" class="bg-white shadowed border-rounded p-4 testimonial__text">
@@ -3611,6 +3613,7 @@
             </blockquote>
           </article>
           <article data-v-599ed6e8="" class="position-relative col-md-4 mt-5 mt-md-0"><img data-v-599ed6e8=""
+              alt="Foto do rosto de uma mulher branca olhando séria para a câmera. Seu cabelo é liso e preto."
               src="data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%221%22%20height%3D%221%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20%25%7Bw%7D%20%25%7Bh%7D%22%20preserveAspectRatio%3D%22none%22%3E%3Crect%20width%3D%22100%25%22%20height%3D%22100%25%22%20style%3D%22fill%3Atransparent%3B%22%3E%3C%2Frect%3E%3C%2Fsvg%3E"
               class="testimonial__image" width="1" height="1">
             <blockquote data-v-599ed6e8="" class="bg-white shadowed border-rounded p-4 testimonial__text">

--- a/Shortstay Curitiba.html
+++ b/Shortstay Curitiba.html
@@ -2545,8 +2545,12 @@
                     <li class="col-12 col-sm-6 col-md-4 col-lg-3"><a
                         href="https://shortstaycuritiba.com.br/flat/all-you-need/studio-CU2709?announce=15318"
                         class="o-home-apartment">
-                        <figure class="o-home-apartment--photo"><img src="Shortstay%20Curitiba_files/1zvi49jsiiw.jpg"
-                            alt="CU2709" width="540" height="330">
+                        <figure class="o-home-apartment--photo">
+                          <img 
+                            src="Shortstay%20Curitiba_files/1zvi49jsiiw.jpg"
+                            alt="Um apartamento com paredes brancas. Em primeiro plano, há uma cama com uma colcha clara. Ao lado da cama há um armário parcialmente contemplado na foto e, na frent do armário, há um puff preto. Na parede oposta à cama e ao armário, há um escrivaninha. Acima da escrivaninha, há uma televisão presa à parede. A frente da escrivaninha, há duas banquetas com assentos pretos e hastes prateadas. Ao lado da escrivaninha, há uma bancada de cozinha preta com uma pia e aproximadamente um metro de espaço livre sobre ela. Abaixo da pia, há um móvel embutido com um forno, um armário e três gavetas. Acima da bancada, há diversos armários e um espaço com um forno de microondas. Ao lado da bancada, há uma geladeira branca, e, ao lado da geladeira, a porta de entrada para o apartamento. O espaço é iluminado por três lâmpadas espalhadas linearmente." 
+                            width="540"
+                            height="330">
                           <figcaption>
                             1700 BRL
                           </figcaption>


### PR DESCRIPTION
# Problema
Diversas imagens não possuem um atributo `alt` relevante nas imagens, não sendo acessíveis aos leitores de tela.

# Solução
Adicionar o atributo `alt` aos elementos `img` com a descrição das respectivas imagens. Foram adicionadas alguns `alt`s nas imagens como exemplo. Como o site possui diversas imagens de apartamentos que são submetidas pelos corretores ou proprietários, podemos separar a solução desse problema em duas partes:

1. No caso das imagens não relacionadas a apartamentos, como as fotos de testemunhos de clientes, não havia nenhum _alt text_. Essas imagens são fixas e tendem a mudar com pouca frequência, portanto a própria equipe do site deve adicionar uma descrição a elas.
2. Já nas imagens de apartamentos, a responsabilidade de escrever os textos pode ser dos corretores ou proprietários que submeterem as fotos. O site pode disponibilizar um espaço para que eles escrevam as descrições de cada foto a ser submetida.