### PR TITLE
Self-closing syntax used on a non-void HTML element

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Foram apontados ao todo 29 problemas no HTML do site. Contudo, diversos dos prob
 
 - [X] An `img` element must have an `alt` attribute, except under certain conditions ([#5](https://github.com/eduardo-otte/acessibilidade-padroes-web/pull/5))
 
-- [ ] Self-closing syntax (`/>`) used on a non-void HTML element. Ignoring the slash and treating as a start tag.
+- [X] Self-closing syntax (`/>`) used on a non-void HTML element. Ignoring the slash and treating as a start tag. ([#6](https://github.com/eduardo-otte/acessibilidade-padroes-web/pull/6))
 
 - [ ] End tag _____ seen, but there were open elements.
 


### PR DESCRIPTION
# Problema
Há uma tag HTML que fecha a si mesma utilizando a sintaxe `/>`, mas que não é um "_[void element](https://html.spec.whatwg.org/multipage/syntax.html#void-elements)_". A mensagem do validador é a seguinte:

- **Self-closing syntax (/>) used on a non-void HTML element. Ignoring the slash and treating as a start tag.**

# Solução
Após inspeção do código fonte da página, percebe-se que assim como em alguns problemas anteriores, isso não é um problema de fato. As tags que foram apontadas como problemáticas foram geradas no próprio browser do usuário, durante a visualização da página, pelo _framework_ utilizado na construção do site.