### PR TITLE
End tag _____ seen, but there were open elements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Foram apontados ao todo 29 problemas no HTML do site. Contudo, diversos dos prob
 
 - [X] Self-closing syntax (`/>`) used on a non-void HTML element. Ignoring the slash and treating as a start tag. ([#6](https://github.com/eduardo-otte/acessibilidade-padroes-web/pull/6))
 
-- [ ] End tag _____ seen, but there were open elements.
+- [X] End tag _____ seen, but there were open elements. ([#7](https://github.com/eduardo-otte/acessibilidade-padroes-web/pull/7))
 
 - [ ] Unclosed element
 


### PR DESCRIPTION
# Problema
Há o fechamento de uma tag HTML antes que uma tag filha fosse fechada. As mensagens do avaliador são as seguintes:

- **End tag `div` seen, but there were open elements.**
- **End tag `ais-instant-search` seen, but there were open elements.**

# Solução
Novamente, uma não-problema identificado pelo avaliador que foi gerado pelo _framework_ utilizado. A inspeção do código fonte nos locais indicados pelo avaliador revelou que o problema apontado não estava lá. Ou seja, as tags "problemáticas" provavelmente foram geradas por um _framework_ JS.